### PR TITLE
loop unswitching and some updates

### DIFF
--- a/src/neural/blas/fully_connected_layer.cc
+++ b/src/neural/blas/fully_connected_layer.cc
@@ -30,24 +30,12 @@ namespace lczero {
 namespace {
 void ApplyBias(size_t batch_size, const size_t output_size, const float* biases,
                const ActivationFunction activation, float* outputs) {
-  if (activation != NONE) {
-    for (size_t i = 0; i < batch_size; i++) {
-      float* batch_outputs = outputs + i * output_size;
-      for (size_t o = 0; o < output_size; o++) {
-        float val = biases[o] + batch_outputs[o];
-        batch_outputs[o] = Activate(val, activation);
-      }
-    }
-  } else {
-    for (size_t i = 0; i < batch_size; i++) {
-      float* batch_outputs = outputs + i * output_size;
-      for (size_t o = 0; o < output_size; o++) {
-        batch_outputs[o] += biases[o];
-      }
-    }
+  for (size_t i = 0; i < batch_size; i++) {
+    float* batch_outputs = outputs + i * output_size;
+    Activate(output_size, batch_outputs, biases, batch_outputs, activation);
   }
 }
-} // namespace
+}  // namespace
 
 template <typename T>
 using EigenVectorMap = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
@@ -152,8 +140,8 @@ void FullyConnectedLayer<true>::Forward1D(
 template <>
 float FullyConnectedLayer<true>::Forward0D(const size_t size, const float* x,
                                            const float* y) {
-  return ConstEigenVectorMap<float>(x, size)
-      .dot(ConstEigenVectorMap<float>(y, size));
+  return ConstEigenVectorMap<float>(x, size).dot(
+      ConstEigenVectorMap<float>(y, size));
 }
 
 }  // namespace lczero

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -245,9 +245,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
     convolve3.Forward(batch_size, kInputPlanes, output_channels, conv_in,
                       weights_.input.weights.data(), conv_out);
 
-    BiasResidualRelu(batch_size, output_channels, conv_out,
-                     weights_.input.biases.data(), nullptr,
-                     default_activation_);
+    BiasResidual(batch_size, output_channels, conv_out,
+                 weights_.input.biases.data(), nullptr, default_activation_);
 
     // Residual tower
 
@@ -261,8 +260,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
       convolve3.Forward(batch_size, output_channels, output_channels, conv_in,
                         conv1.weights.data(), conv_out);
 
-      BiasResidualRelu(batch_size, output_channels, &conv_out[0],
-                       conv1.biases.data(), nullptr, default_activation_);
+      BiasResidual(batch_size, output_channels, &conv_out[0],
+                   conv1.biases.data(), nullptr, default_activation_);
 
       std::swap(conv_in, res);
       std::swap(conv_out, conv_in);
@@ -272,8 +271,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
 
       if (residual.has_se) {
         // No relu if followed by SE-unit and residual is added later
-        BiasResidualRelu(batch_size, output_channels, &conv_out[0],
-                         conv2.biases.data(), nullptr, NONE);
+        BiasResidual(batch_size, output_channels, &conv_out[0],
+                     conv2.biases.data(), nullptr, NONE);
 
         std::swap(conv_out, conv_in);
 
@@ -283,8 +282,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
                                se.w2.data(), se.b2.data(), conv_out,
                                default_activation_);
       } else {
-        BiasResidualRelu(batch_size, output_channels, &conv_out[0],
-                         conv2.biases.data(), res, default_activation_);
+        BiasResidual(batch_size, output_channels, &conv_out[0],
+                     conv2.biases.data(), res, default_activation_);
       }
     }
 
@@ -390,17 +389,16 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
       convolve3.Forward(batch_size, output_channels, output_channels, conv_out,
                         weights_.policy1.weights.data(), res);
 
-      BiasResidualRelu(batch_size, output_channels, &res[0],
-                       weights_.policy1.biases.data(), nullptr,
-                       default_activation_);
+      BiasResidual(batch_size, output_channels, &res[0],
+                   weights_.policy1.biases.data(), nullptr,
+                   default_activation_);
 
       convolve3.Forward(batch_size, output_channels, num_policy_input_planes,
                         res, weights_.policy.weights.data(),
                         head_buffer.data());
 
-      BiasResidualRelu(batch_size, num_policy_input_planes,
-                       &head_buffer.data()[0], weights_.policy.biases.data(),
-                       nullptr, NONE);
+      BiasResidual(batch_size, num_policy_input_planes, &head_buffer.data()[0],
+                   weights_.policy.biases.data(), nullptr, NONE);
 
       // Mapping from convolutional policy to lc0 policy
       for (auto batch = size_t{0}; batch < batch_size; batch++) {
@@ -418,9 +416,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
           batch_size, output_channels, num_policy_input_planes, conv_out,
           weights_.policy.weights.data(), head_buffer.data());
 
-      BiasResidualRelu(batch_size, num_policy_input_planes, &head_buffer[0],
-                       weights_.policy.biases.data(), nullptr,
-                       default_activation_);
+      BiasResidual(batch_size, num_policy_input_planes, &head_buffer[0],
+                   weights_.policy.biases.data(), nullptr, default_activation_);
 
       FullyConnectedLayer<use_eigen>::Forward1D(
           batch_size, num_policy_input_planes * kSquares, num_output_policy,
@@ -444,9 +441,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
         batch_size, output_channels, num_value_input_planes, conv_out,
         weights_.value.weights.data(), head_buffer.data());
 
-    BiasResidualRelu(batch_size, num_value_input_planes, &head_buffer[0],
-                     weights_.value.biases.data(), nullptr,
-                     default_activation_);
+    BiasResidual(batch_size, num_value_input_planes, &head_buffer[0],
+                 weights_.value.biases.data(), nullptr, default_activation_);
 
     FullyConnectedLayer<use_eigen>::Forward1D(
         batch_size, num_value_input_planes * kSquares, num_value_channels,
@@ -487,9 +483,9 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
           batch_size, output_channels, num_moves_input_planes, conv_out,
           weights_.moves_left.weights.data(), head_buffer.data());
 
-      BiasResidualRelu(batch_size, num_moves_input_planes, &head_buffer[0],
-                       weights_.moves_left.biases.data(), nullptr,
-                       default_activation_);
+      BiasResidual(batch_size, num_moves_input_planes, &head_buffer[0],
+                   weights_.moves_left.biases.data(), nullptr,
+                   default_activation_);
 
       FullyConnectedLayer<use_eigen>::Forward1D(
           batch_size, num_moves_input_planes * kSquares, num_moves_channels,

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -245,8 +245,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
     convolve3.Forward(batch_size, kInputPlanes, output_channels, conv_in,
                       weights_.input.weights.data(), conv_out);
 
-    BiasResidual(batch_size, output_channels, conv_out,
-                 weights_.input.biases.data(), nullptr, default_activation_);
+    BiasActivate(batch_size, output_channels, conv_out,
+                 weights_.input.biases.data(), default_activation_);
 
     // Residual tower
 
@@ -260,8 +260,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
       convolve3.Forward(batch_size, output_channels, output_channels, conv_in,
                         conv1.weights.data(), conv_out);
 
-      BiasResidual(batch_size, output_channels, &conv_out[0],
-                   conv1.biases.data(), nullptr, default_activation_);
+      BiasActivate(batch_size, output_channels, &conv_out[0],
+                   conv1.biases.data(), default_activation_);
 
       std::swap(conv_in, res);
       std::swap(conv_out, conv_in);
@@ -271,8 +271,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
 
       if (residual.has_se) {
         // No relu if followed by SE-unit and residual is added later
-        BiasResidual(batch_size, output_channels, &conv_out[0],
-                     conv2.biases.data(), nullptr, NONE);
+        BiasActivate(batch_size, output_channels, &conv_out[0],
+                     conv2.biases.data(), NONE);
 
         std::swap(conv_out, conv_in);
 
@@ -389,16 +389,15 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
       convolve3.Forward(batch_size, output_channels, output_channels, conv_out,
                         weights_.policy1.weights.data(), res);
 
-      BiasResidual(batch_size, output_channels, &res[0],
-                   weights_.policy1.biases.data(), nullptr,
-                   default_activation_);
+      BiasActivate(batch_size, output_channels, &res[0],
+                   weights_.policy1.biases.data(), default_activation_);
 
       convolve3.Forward(batch_size, output_channels, num_policy_input_planes,
                         res, weights_.policy.weights.data(),
                         head_buffer.data());
 
-      BiasResidual(batch_size, num_policy_input_planes, &head_buffer.data()[0],
-                   weights_.policy.biases.data(), nullptr, NONE);
+      BiasActivate(batch_size, num_policy_input_planes, &head_buffer.data()[0],
+                   weights_.policy.biases.data(), NONE);
 
       // Mapping from convolutional policy to lc0 policy
       for (auto batch = size_t{0}; batch < batch_size; batch++) {
@@ -416,8 +415,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
           batch_size, output_channels, num_policy_input_planes, conv_out,
           weights_.policy.weights.data(), head_buffer.data());
 
-      BiasResidual(batch_size, num_policy_input_planes, &head_buffer[0],
-                   weights_.policy.biases.data(), nullptr, default_activation_);
+      BiasActivate(batch_size, num_policy_input_planes, &head_buffer[0],
+                   weights_.policy.biases.data(), default_activation_);
 
       FullyConnectedLayer<use_eigen>::Forward1D(
           batch_size, num_policy_input_planes * kSquares, num_output_policy,
@@ -441,8 +440,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
         batch_size, output_channels, num_value_input_planes, conv_out,
         weights_.value.weights.data(), head_buffer.data());
 
-    BiasResidual(batch_size, num_value_input_planes, &head_buffer[0],
-                 weights_.value.biases.data(), nullptr, default_activation_);
+    BiasActivate(batch_size, num_value_input_planes, &head_buffer[0],
+                 weights_.value.biases.data(), default_activation_);
 
     FullyConnectedLayer<use_eigen>::Forward1D(
         batch_size, num_value_input_planes * kSquares, num_value_channels,
@@ -483,9 +482,8 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
           batch_size, output_channels, num_moves_input_planes, conv_out,
           weights_.moves_left.weights.data(), head_buffer.data());
 
-      BiasResidual(batch_size, num_moves_input_planes, &head_buffer[0],
-                   weights_.moves_left.biases.data(), nullptr,
-                   default_activation_);
+      BiasActivate(batch_size, num_moves_input_planes, &head_buffer[0],
+                   weights_.moves_left.biases.data(), default_activation_);
 
       FullyConnectedLayer<use_eigen>::Forward1D(
           batch_size, num_moves_input_planes * kSquares, num_moves_channels,

--- a/src/neural/blas/se_unit.cc
+++ b/src/neural/blas/se_unit.cc
@@ -42,7 +42,6 @@ static void global_avg_pooling(const size_t channels, const float* input,
 static void apply_se(const size_t channels, const size_t batch_size,
                      const float* input, const float* res, const float* scale,
                      float* output, const ActivationFunction activation) {
-
   const auto lambda_sigmoid = [](const auto val) {
     return 1.0f / (1.0f + std::exp(-val));
   };
@@ -51,11 +50,8 @@ static void apply_se(const size_t channels, const size_t batch_size,
     auto batch = c / channels;
     auto gamma = lambda_sigmoid(scale[c + batch * channels]);
     auto beta = scale[c + batch * channels + channels];
-    for (auto i = size_t{0}; i < kSquares; i++) {
-      output[c * kSquares + i] = Activate(
-          gamma * input[c * kSquares + i] + beta + res[c * kSquares + i],
-          activation);
-    }
+    Activate(kSquares, gamma, &input[c * kSquares], &res[c * kSquares], beta,
+             &output[c * kSquares], activation);
   }
 }
 
@@ -83,7 +79,8 @@ void ApplySEUnit(const size_t batch_size, const size_t channels,
                                             pool.data());
 
   // Sigmoid, scale and add residual
-  apply_se(channels, batch_size, input, residual, pool.data(), output, activation);
+  apply_se(channels, batch_size, input, residual, pool.data(), output,
+           activation);
 }
 
 template void ApplySEUnit<true>(const size_t batch_size, const size_t channels,

--- a/src/neural/shared/activation.cc
+++ b/src/neural/shared/activation.cc
@@ -42,32 +42,38 @@ void SoftmaxActivation(const size_t size, const float* input, float* output) {
   }
 }
 
+static inline float mish(float val) {
+  auto e = expf(val);
+  auto n = e * e + 2.0f * e;
+  auto d = val / (n + 2.0f);
+  if (val <= -0.125f) {
+    return n * d;
+  } else {
+    return val - 2.0f * d;
+  }
+}
+
+static inline float selu(float val) {
+  float alpha = 1.67326324f, scale = 1.05070098f;
+  if (val > 0) {
+    return scale * val;
+  } else {
+    return scale * alpha * (expf(val) - 1.0f);
+  }
+}
+
 float Activate(const float val, const ActivationFunction activation) {
   switch (activation) {
     case RELU:
       return val > 0 ? val : 0;
-    case MISH: {
-      auto e = expf(val);
-      auto n = e * e + 2.0f * e;
-      auto d = val / (n + 2.0f);
-      if (val <= -0.125f) {
-        return n * d;
-      } else {
-        return val - 2.0f * d;
-      }
-    }
+    case MISH:
+      return mish(val);
     case TANH:
       return tanhf(val);
     case SIGMOID:
       return 1.0f / (1.0f + expf(-val));
-    case SELU: {
-      float alpha = 1.67326324f, scale = 1.05070098f;
-      if (val > 0) {
-        return scale * val;
-      } else {
-        return scale * alpha * (expf(val) - 1.0f);
-      }
-    }
+    case SELU:
+      return selu(val);
     case NONE:
       // Nothing to do.
       break;
@@ -89,14 +95,7 @@ void Activate(const size_t len, const float* data, const float* bias,
   } else if (activation == MISH) {
     for (size_t b = 0; b < len; b++) {
       float val = data[b] + bias[b];
-      auto e = expf(val);
-      auto n = e * e + 2.0f * e;
-      auto d = val / (n + 2.0f);
-      if (val <= -0.125f) {
-        output[b] = n * d;
-      } else {
-        output[b] = val - 2.0f * d;
-      }
+      output[b] = mish(val);
     }
   } else {
     for (size_t b = 0; b < len; b++) {
@@ -122,14 +121,7 @@ void Activate(const size_t len, float gamma, const float* data,
   } else if (activation == MISH) {
     for (size_t b = 0; b < len; b++) {
       float val = gamma * data[b] + bias[b] + beta;
-      auto e = expf(val);
-      auto n = e * e + 2.0f * e;
-      auto d = val / (n + 2.0f);
-      if (val <= -0.125f) {
-        output[b] = n * d;
-      } else {
-        output[b] = val - 2.0f * d;
-      }
+      output[b] = mish(val);
     }
   } else {
     for (size_t b = 0; b < len; b++) {
@@ -146,83 +138,72 @@ void BiasResidual(const size_t batch_size, const size_t channels, float* data,
     for (size_t c = 0; c < channels; ++c) {
       auto bias = biases[c];
       if (activation == NONE) {
-        if (eltwise == nullptr) {
-          auto arr = &data[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = arr[b] + bias;
-            arr[b] = val;
-          }
-        } else {
-          auto arr = &data[c * kSquares];
-          auto res = &eltwise[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = res[b] + arr[b] + bias;
-            arr[b] = val;
-          }
+        auto arr = &data[c * kSquares];
+        auto res = &eltwise[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = res[b] + arr[b] + bias;
+          arr[b] = val;
         }
       } else if (activation == RELU) {
-        if (eltwise == nullptr) {
-          auto arr = &data[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = arr[b] + bias;
-            arr[b] = val > 0 ? val : 0;
-          }
-        } else {
-          auto arr = &data[c * kSquares];
-          auto res = &eltwise[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = res[b] + arr[b] + bias;
-            arr[b] = val > 0 ? val : 0;
-          }
+        auto arr = &data[c * kSquares];
+        auto res = &eltwise[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = res[b] + arr[b] + bias;
+          arr[b] = val > 0 ? val : 0;
         }
       } else if (activation == MISH) {
-        if (eltwise == nullptr) {
-          auto arr = &data[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = arr[b] + bias;
-            auto e = expf(val);
-            auto n = e * e + 2.0f * e;
-            auto d = val / (n + 2.0f);
-            if (val <= -0.125f) {
-              arr[b] = n * d;
-            } else {
-              arr[b] = val - 2.0f * d;
-            }
-          }
-        } else {
-          auto arr = &data[c * kSquares];
-          auto res = &eltwise[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = res[b] + arr[b] + bias;
-            auto e = expf(val);
-            auto n = e * e + 2.0f * e;
-            auto d = val / (n + 2.0f);
-            if (val <= -0.125f) {
-              arr[b] = n * d;
-            } else {
-              arr[b] = val - 2.0f * d;
-            }
-          }
+        auto arr = &data[c * kSquares];
+        auto res = &eltwise[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = res[b] + arr[b] + bias;
+          arr[b] = mish(val);
         }
       } else {
-        if (eltwise == nullptr) {
-          auto arr = &data[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = arr[b] + bias;
-            arr[b] = Activate(val, activation);
-          }
-        } else {
-          auto arr = &data[c * kSquares];
-          auto res = &eltwise[c * kSquares];
-          for (size_t b = 0; b < kSquares; b++) {
-            float val = res[b] + arr[b] + bias;
-            arr[b] = Activate(val, activation);
-          }
+        auto arr = &data[c * kSquares];
+        auto res = &eltwise[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = res[b] + arr[b] + bias;
+          arr[b] = Activate(val, activation);
         }
       }
     }
     data += channels * kSquares;
-    if (eltwise != nullptr) eltwise += channels * kSquares;
+    eltwise += channels * kSquares;
+  }
+}
+
+void BiasActivate(const size_t batch_size, const size_t channels, float* data,
+                  const float* biases, const ActivationFunction activation) {
+  for (size_t i = 0; i < batch_size; i++) {
+    for (size_t c = 0; c < channels; ++c) {
+      auto bias = biases[c];
+      if (activation == NONE) {
+        auto arr = &data[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = arr[b] + bias;
+          arr[b] = val;
+        }
+      } else if (activation == RELU) {
+        auto arr = &data[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = arr[b] + bias;
+          arr[b] = val > 0 ? val : 0;
+        }
+      } else if (activation == MISH) {
+        auto arr = &data[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = arr[b] + bias;
+          arr[b] = mish(val);
+        }
+      } else {
+        auto arr = &data[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = arr[b] + bias;
+          arr[b] = Activate(val, activation);
+        }
+      }
+    }
+    data += channels * kSquares;
   }
 }
 

--- a/src/neural/shared/activation.cc
+++ b/src/neural/shared/activation.cc
@@ -50,7 +50,11 @@ float Activate(const float val, const ActivationFunction activation) {
       auto e = expf(val);
       auto n = e * e + 2.0f * e;
       auto d = val / (n + 2.0f);
-      return n * d;
+      if (val <= -0.125f) {
+        return n * d;
+      } else {
+        return val - 2.0f * d;
+      }
     }
     case TANH:
       return tanhf(val);
@@ -88,7 +92,11 @@ void Activate(const size_t len, const float* data, const float* bias,
       auto e = expf(val);
       auto n = e * e + 2.0f * e;
       auto d = val / (n + 2.0f);
-      output[b] = n * d;
+      if (val <= -0.125f) {
+        output[b] = n * d;
+      } else {
+        output[b] = val - 2.0f * d;
+      }
     }
   } else {
     for (size_t b = 0; b < len; b++) {
@@ -117,7 +125,11 @@ void Activate(const size_t len, float gamma, const float* data,
       auto e = expf(val);
       auto n = e * e + 2.0f * e;
       auto d = val / (n + 2.0f);
-      output[b] = n * d;
+      if (val <= -0.125f) {
+        output[b] = n * d;
+      } else {
+        output[b] = val - 2.0f * d;
+      }
     }
   } else {
     for (size_t b = 0; b < len; b++) {
@@ -171,7 +183,11 @@ void BiasResidual(const size_t batch_size, const size_t channels, float* data,
             auto e = expf(val);
             auto n = e * e + 2.0f * e;
             auto d = val / (n + 2.0f);
-            arr[b] = n * d;
+            if (val <= -0.125f) {
+              arr[b] = n * d;
+            } else {
+              arr[b] = val - 2.0f * d;
+            }
           }
         } else {
           auto arr = &data[c * kSquares];
@@ -181,7 +197,11 @@ void BiasResidual(const size_t batch_size, const size_t channels, float* data,
             auto e = expf(val);
             auto n = e * e + 2.0f * e;
             auto d = val / (n + 2.0f);
-            arr[b] = n * d;
+            if (val <= -0.125f) {
+              arr[b] = n * d;
+            } else {
+              arr[b] = val - 2.0f * d;
+            }
           }
         }
       } else {

--- a/src/neural/shared/activation.h
+++ b/src/neural/shared/activation.h
@@ -27,10 +27,9 @@ enum ActivationFunction { NONE, RELU, TANH, SIGMOID, SELU, MISH };
 // Softmax activation
 void SoftmaxActivation(const size_t size, const float* input, float* output);
 
-void BiasResidualRelu(const size_t batch_size, const size_t channels,
-                      float* data, const float* biases,
-                      const float* eltwise = nullptr,
-                      const ActivationFunction activation = RELU);
+void BiasResidual(const size_t batch_size, const size_t channels, float * data,
+                  const float* biases, const float* eltwise = nullptr,
+                  const ActivationFunction activation = RELU);
 
 float Activate(const float val, const ActivationFunction activation);
 

--- a/src/neural/shared/activation.h
+++ b/src/neural/shared/activation.h
@@ -24,15 +24,21 @@
 namespace lczero {
 enum ActivationFunction { NONE, RELU, TANH, SIGMOID, SELU, MISH };
 
-  // Softmax activation
+// Softmax activation
 void SoftmaxActivation(const size_t size, const float* input, float* output);
 
 void BiasResidualRelu(const size_t batch_size, const size_t channels,
-                 float* data, const float* biases,
-                 const float* eltwise = nullptr,
-                 const ActivationFunction activation = RELU);
-float Activate(const float val,
+                      float* data, const float* biases,
+                      const float* eltwise = nullptr,
+                      const ActivationFunction activation = RELU);
+
+float Activate(const float val, const ActivationFunction activation);
+
+void Activate(const size_t len, const float* data, const float* bias,
+              float* output, const ActivationFunction activation);
+
+void Activate(const size_t len, float gamma, const float* data,
+              const float* bias, float beta, float* out,
               const ActivationFunction activation);
-void Activate(const size_t len, float* data,
-              const ActivationFunction activation);
+
 }  // namespace lczero

--- a/src/neural/shared/activation.h
+++ b/src/neural/shared/activation.h
@@ -28,7 +28,11 @@ enum ActivationFunction { NONE, RELU, TANH, SIGMOID, SELU, MISH };
 void SoftmaxActivation(const size_t size, const float* input, float* output);
 
 void BiasResidual(const size_t batch_size, const size_t channels, float * data,
-                  const float* biases, const float* eltwise = nullptr,
+                  const float* biases, const float* eltwise,
+                  const ActivationFunction activation = RELU);
+
+void BiasActivate(const size_t batch_size, const size_t channels, float * data,
+                  const float* biases,
                   const ActivationFunction activation = RELU);
 
 float Activate(const float val, const ActivationFunction activation);


### PR DESCRIPTION
The first version was 10% slower (with relu), this does some manual loop unswitching to get it back (might even be marginally faster). This is a bit messy, but I couldn't find a cleaner version that retained the full speed gains. Only relu, mish and no activation have fast paths to reduce bloat.

Also renamed `BiasResidualRelu` to `BiasResidual` ~~and simplified the mish formula as the original version was tuned for cuda approximations~~.